### PR TITLE
Improve styles with cljfmt

### DIFF
--- a/examples/cnn-text-classification/project.clj
+++ b/examples/cnn-text-classification/project.clj
@@ -17,6 +17,7 @@
 
 (defproject cnn-text-classification "0.1.0-SNAPSHOT"
   :description "CNN text classification with MXNet"
+  :plugins [[lein-cljfmt "0.5.7"]]
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [org.apache.mxnet.contrib.clojure/clojure-mxnet "1.2.1-SNAPSHOT"]]
   :main cnn-text-classification.classifier

--- a/examples/cnn-text-classification/src/cnn_text_classification/classifier.clj
+++ b/examples/cnn-text-classification/src/cnn_text_classification/classifier.clj
@@ -40,11 +40,11 @@
         test (into [] (drop train-num shuffled))]
     {:training {:data  (ndarray/array (into [] (flatten (mapv (fn [v] (first v)) training)))
                                       [train-num 1 sentence-size embedding-size]) ;; has to be channel x y
-                :label (ndarray/array (into [] (flatten (mapv (fn [v] (last v) ) training)))
+                :label (ndarray/array (into [] (flatten (mapv (fn [v] (last v)) training)))
                                       [train-num])}
      :test {:data  (ndarray/array (into [] (flatten (mapv (fn [v] (first v)) test)))
                                   [test-num 1 sentence-size embedding-size]) ;; has to be channel x y
-            :label (ndarray/array (into [] (flatten (mapv (fn [v] (last v) ) test)))
+            :label (ndarray/array (into [] (flatten (mapv (fn [v] (last v)) test)))
                                   [test-num])}}))
 
 ;;; convnet with multiple filter sizes
@@ -78,12 +78,12 @@
         sentence-size (:sentence-size ms-dataset)
         shuffled (shuffle-data test-size ms-dataset)
         train-data (mx-io/ndarray-iter [(get-in shuffled [:training :data])]
-                                       {:label[(get-in  shuffled [:training :label])]
+                                       {:label [(get-in  shuffled [:training :label])]
                                         :label-name "softmax_label"
                                         :data-batch-size batch-size
                                         :last-batch-handle "pad"})
         test-data (mx-io/ndarray-iter [(get-in shuffled [:test :data])]
-                                      {:label[(get-in  shuffled [:test :label])]
+                                      {:label [(get-in  shuffled [:test :label])]
                                        :label-name "softmax_label"
                                        :data-batch-size batch-size
                                        :last-batch-handle "pad"})]
@@ -105,8 +105,6 @@
     ;; runs all the examples
     #_(train-convnet {:embedding-size 50 :batch-size 100 :test-size 1000 :num-epoch 10})))
 
-
 (comment
-  (train-convnet {:devs [(context/cpu)] :embedding-size 50 :batch-size 10 :test-size 100 :num-epoch 10 :max-examples 1000})
-  )
+  (train-convnet {:devs [(context/cpu)] :embedding-size 50 :batch-size 10 :test-size 100 :num-epoch 10 :max-examples 1000}))
 

--- a/examples/cnn-text-classification/src/cnn_text_classification/data_helper.clj
+++ b/examples/cnn-text-classification/src/cnn_text_classification/data_helper.clj
@@ -42,7 +42,6 @@
         (.append sb (new String bs 0 i))))
     (.toString sb)))
 
-
 (defn get-float [b]
   (-> 0
       (bit-or (bit-shift-left (bit-and (aget b 0) 0xff) 0))
@@ -70,31 +69,27 @@
       (println "Finished")
       {:num-embed dim :word2vec word2vec})))
 
-
 (defn clean-str [s]
   (-> s
-    (string/replace #"^A-Za-z0-9(),!?'`]" " ")
-    (string/replace #"'s" " 's")
-    (string/replace #"'ve" " 've")
-    (string/replace #"n't" " n't")
-    (string/replace #"'re" " 're")
-    (string/replace #"'d" " 'd")
-    (string/replace #"'ll" " 'll")
-    (string/replace #"," " , ")
-    (string/replace #"!" " ! ")
-    (string/replace #"\(" " ( ")
-    (string/replace #"\)" " ) ")
-    (string/replace #"\?" " ? ")
-    (string/replace #" {2,}" " ")
-    (string/trim)))
-
-
- ;; Loads MR polarity data from files, splits the data into words and generates labels.
+      (string/replace #"^A-Za-z0-9(),!?'`]" " ")
+      (string/replace #"'s" " 's")
+      (string/replace #"'ve" " 've")
+      (string/replace #"n't" " n't")
+      (string/replace #"'re" " 're")
+      (string/replace #"'d" " 'd")
+      (string/replace #"'ll" " 'll")
+      (string/replace #"," " , ")
+      (string/replace #"!" " ! ")
+      (string/replace #"\(" " ( ")
+      (string/replace #"\)" " ) ")
+      (string/replace #"\?" " ? ")
+      (string/replace #" {2,}" " ")
+      (string/trim)));; Loads MR polarity data from files, splits the data into words and generates labels.
  ;; Returns split sentences and labels.
 (defn load-mr-data-and-labels [path max-examples]
   (println "Loading all the movie reviews from " path)
   (let [positive-examples (mapv #(string/trim %) (-> (slurp (str path "/rt-polarity.pos"))
-                                                    (string/split #"\n")))
+                                                     (string/split #"\n")))
         negative-examples (mapv #(string/trim %) (-> (slurp (str path "/rt-polarity.neg"))
                                                      (string/split #"\n")))
         positive-examples (into [] (if max-examples (take max-examples positive-examples) positive-examples))
@@ -118,10 +113,7 @@
                     (if (pos? diff)
                       (into s (repeat diff padding-word))
                       s)))
-          sentences)))
-
-
- ;; Map sentences and labels to vectors based on a pretrained embeddings
+          sentences)));; Map sentences and labels to vectors based on a pretrained embeddings
 (defn build-input-data-with-embeddings [sentences embedding-size embeddings]
   (mapv (fn [sent]
           (mapv (fn [word] (or (get embeddings word)

--- a/examples/gan/project.clj
+++ b/examples/gan/project.clj
@@ -17,6 +17,7 @@
 
 (defproject gan "0.1.0-SNAPSHOT"
   :description "GAN MNIST with MXNet"
+  :plugins [[lein-cljfmt "0.5.7"]]
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [org.apache.mxnet.contrib.clojure/clojure-mxnet "1.2.1-SNAPSHOT"]
                  [nu.pattern/opencv "2.4.9-7"]]

--- a/examples/gan/src/gan/viz.clj
+++ b/examples/gan/src/gan/viz.clj
@@ -27,7 +27,6 @@
 ;;; Viz stuff
 (OpenCV/loadShared)
 
-
 (defn clip [x]
   (->> x
        (mapv #(* 255 %))
@@ -69,7 +68,7 @@
         [n c h w] shape
         totals (* h w)
         raw-data (byte-array (clip (ndarray/to-array x)))
-        row (.intValue(Math/sqrt n))
+        row (.intValue (Math/sqrt n))
         col row
         line-arrs (into [] (partition (* col c totals) raw-data))
         line-mats (mapv (fn [line]

--- a/examples/imclassification/project.clj
+++ b/examples/imclassification/project.clj
@@ -17,6 +17,7 @@
 
 (defproject imclassification "0.1.0-SNAPSHOT"
   :description "Clojure examples for image classification"
+  :plugins [[lein-cljfmt "0.5.7"]]
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [org.apache.mxnet.contrib.clojure/clojure-mxnet "1.2.1-SNAPSHOT"]]
   :main imclassification.train-mnist

--- a/examples/imclassification/src/imclassification/train_mnist.clj
+++ b/examples/imclassification/src/imclassification/train_mnist.clj
@@ -111,5 +111,4 @@
     (start devs)))
 
 (comment
-  (start [(context/cpu)])
-  )
+  (start [(context/cpu)]))

--- a/examples/lein-cljfmt-check
+++ b/examples/lein-cljfmt-check
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+for dir in $(find . -type d -depth 1 | grep -v scripts)
+do
+  cd $dir
+  lein cljfmt check
+  cd ..
+done

--- a/examples/lein-cljfmt-fix
+++ b/examples/lein-cljfmt-fix
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+for dir in $(find . -type d -depth 1 | grep -v scripts)
+do
+  cd $dir
+  lein cljfmt fix
+  cd ..
+done

--- a/examples/module/project.clj
+++ b/examples/module/project.clj
@@ -17,6 +17,7 @@
 
 (defproject module-examples "0.1.0-SNAPSHOT"
   :description "Clojure examples for module"
+  :plugins [[lein-cljfmt "0.5.7"]]
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [org.apache.mxnet.contrib.clojure/clojure-mxnet "1.2.1-SNAPSHOT"]]
   :main  mnist-mlp

--- a/examples/module/src/mnist_mlp.clj
+++ b/examples/module/src/mnist_mlp.clj
@@ -116,7 +116,6 @@
     (let [score (m/score mod {:eval-data test-data :eval-metric (eval-metric/accuracy)})]
       (println "High level predict score is " score))))
 
-
 (defn run-predication-and-calc-accuracy-manually [devs]
   ;;; Gathers all the predictions at once with `predict-every-batch`
   ;;; then cycles thorugh the batches and manually calculates the accuracy stats
@@ -128,23 +127,23 @@
     (m/fit mod {:train-data train-data :eval-data test-data :num-epoch num-epoch})
     (let [preds (m/predict-every-batch mod {:eval-data test-data})
           stats (mx-io/reduce-batches test-data
-                         (fn [r b]
-                           (let [pred-label (->> (ndarray/argmax-channel (first (get preds (:index r))))
-                                                 (ndarray/->vec)
-                                                 (mapv int))
-                                 label (->> (mx-io/batch-label b)
-                                            (first)
-                                            (ndarray/->vec)
-                                            (mapv int))
-                                 acc-sum (apply + (mapv (fn [pl l] (if (= pl l) 1 0))
-                                                        pred-label label))]
-                             (-> r
-                                 (update :index inc)
-                                 (update :acc-cnt (fn [v] (+ v (count pred-label))))
-                                 (update :acc-sum (fn [v] (+ v
-                                                             (apply + (mapv (fn [pl l] (if (= pl l) 1 0))
-                                                                            pred-label label))))))))
-                         {:acc-sum 0 :acc-cnt 0 :index 0})]
+                                      (fn [r b]
+                                        (let [pred-label (->> (ndarray/argmax-channel (first (get preds (:index r))))
+                                                              (ndarray/->vec)
+                                                              (mapv int))
+                                              label (->> (mx-io/batch-label b)
+                                                         (first)
+                                                         (ndarray/->vec)
+                                                         (mapv int))
+                                              acc-sum (apply + (mapv (fn [pl l] (if (= pl l) 1 0))
+                                                                     pred-label label))]
+                                          (-> r
+                                              (update :index inc)
+                                              (update :acc-cnt (fn [v] (+ v (count pred-label))))
+                                              (update :acc-sum (fn [v] (+ v
+                                                                          (apply + (mapv (fn [pl l] (if (= pl l) 1 0))
+                                                                                         pred-label label))))))))
+                                      {:acc-sum 0 :acc-cnt 0 :index 0})]
       (println "Stats: " stats)
       (println "Accuracy: " (/ (:acc-sum stats)
                                (* 1.0 (:acc-cnt stats)))))))
@@ -159,19 +158,19 @@
     ;;; note only one function for training
     (m/fit mod {:train-data train-data :eval-data test-data :num-epoch num-epoch})
     (mx-io/reduce-batches test-data
-                        (fn [r b]
-                          (let [preds (m/predict-batch mod b)
-                                pred-label (->> (ndarray/argmax-channel (first preds))
-                                                (ndarray/->vec)
-                                                (mapv int))
-                                label (->> (mx-io/batch-label b)
-                                           (first)
-                                           (ndarray/->vec)
-                                           (mapv int))
-                                acc (/ (apply + (mapv (fn [pl l] (if (= pl l) 1 0)) pred-label label))
-                                       (* 1.0 (count pred-label)))]
-                            (println "Batch " r " acc: " acc)
-                            (inc r))))))
+                          (fn [r b]
+                            (let [preds (m/predict-batch mod b)
+                                  pred-label (->> (ndarray/argmax-channel (first preds))
+                                                  (ndarray/->vec)
+                                                  (mapv int))
+                                  label (->> (mx-io/batch-label b)
+                                             (first)
+                                             (ndarray/->vec)
+                                             (mapv int))
+                                  acc (/ (apply + (mapv (fn [pl l] (if (= pl l) 1 0)) pred-label label))
+                                         (* 1.0 (count pred-label)))]
+                              (println "Batch " r " acc: " acc)
+                              (inc r))))))
 
 (defn run-all [devs]
   (run-intermediate-level-api :devs devs)
@@ -189,7 +188,6 @@
     (println "Running Module MNIST example")
     (println "Running with context devices of" devs)
     (run-all devs)))
-
 
 (comment
 
@@ -236,5 +234,4 @@
   ;;=> Stats:  {:acc-sum 9494, :acc-cnt 10000, :index 1000}
   ;;=> Accuracy:  0.9494
 )
-
 

--- a/examples/multi-label/project.clj
+++ b/examples/multi-label/project.clj
@@ -17,6 +17,7 @@
 
 (defproject multi-label "0.1.0-SNAPSHOT"
   :description "Example of multi-label classification"
+  :plugins [[lein-cljfmt "0.5.7"]]
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [org.apache.mxnet.contrib.clojure/clojure-mxnet "1.2.1-SNAPSHOT"]]
   :main multi-label.core)

--- a/examples/multi-label/src/multi_label/core.clj
+++ b/examples/multi-label/src/multi_label/core.clj
@@ -30,7 +30,6 @@
            (java.util NoSuchElementException))
   (:gen-class))
 
-
 (def data-dir "data/")
 (def batch-size 100)
 (def num-epoch 1)
@@ -101,8 +100,8 @@
                                              (vals)
                                              last)]
                               (util/list-map
-                                        {"softmax1_label" (mx-shape/->shape shape)
-                                         "softmax2_label" (mx-shape/->shape shape)})))
+                               {"softmax1_label" (mx-shape/->shape shape)
+                                "softmax2_label" (mx-shape/->shape shape)})))
                           (provideData []
                             (.provideData data-iter)))))
 
@@ -153,7 +152,7 @@
                           (update :batch-num inc))))
                   {:sum [0 0] :batch-num 0})]
         (println "Multi-accuracy " acc)
-        (println "Multi-accuracy "(mapv #(/ % (:batch-num acc)) (:sum acc)))))))
+        (println "Multi-accuracy " (mapv #(/ % (:batch-num acc)) (:sum acc)))))))
 
 (defn -main [& args]
   (let [[dev dev-num] args
@@ -163,7 +162,6 @@
     (println "Training...")
     (println "Running with context devices of" devs)
     (train devs)))
-
 
 (comment
   (train [(context/cpu)]))

--- a/examples/neural-style/project.clj
+++ b/examples/neural-style/project.clj
@@ -17,9 +17,9 @@
 
 (defproject neural-style "0.1.0-SNAPSHOT"
   :description "Neural Style Transfer with MXNet"
+  :plugins [[lein-cljfmt "0.5.7"]]
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [org.apache.mxnet.contrib.clojure/clojure-mxnet "1.2.1-SNAPSHOT"]
                  [net.mikera/imagez "0.12.0"]
                  [thinktopic/think.image "0.4.16"]]
-  :main neural-style.core
-)
+  :main neural-style.core)

--- a/examples/neural-style/src/neural_style/model_vgg_19.clj
+++ b/examples/neural-style/src/neural_style/model_vgg_19.clj
@@ -71,7 +71,6 @@
         content (sym/group [relu1-1])]
     {:style style :content content}))
 
-
 (defn get-executor [style content model-path input-size ctx]
   (let [out (sym/group [style content])
         ;; make executor
@@ -83,12 +82,12 @@
         ;;; I'm not sure this is being set properly
         pretrained (do (ndarray/load model-path))
         arg-map (into {} (mapv (fn [[k v]]
-                           (let [pretrained-key (str "arg:" k)]
-                             (if (and (get pretrained pretrained-key) (not= "data" k))
-                               (do (ndarray/set v (get pretrained pretrained-key))
-                                   [k v])
-                               [k v])))
-                         arg-map))
+                                 (let [pretrained-key (str "arg:" k)]
+                                   (if (and (get pretrained pretrained-key) (not= "data" k))
+                                     (do (ndarray/set v (get pretrained pretrained-key))
+                                         [k v])
+                                     [k v])))
+                               arg-map))
         exec (sym/bind out ctx arg-map grad-map)
         outs (executor/outputs exec)]
     {:executor exec

--- a/examples/pre-trained-models/project.clj
+++ b/examples/pre-trained-models/project.clj
@@ -17,6 +17,7 @@
 
 (defproject pre-trained-models "0.1.0-SNAPSHOT"
   :description "Example of using pre-trained models with MXNet"
+  :plugins [[lein-cljfmt "0.5.7"]]
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [org.apache.mxnet.contrib.clojure/clojure-mxnet "1.2.1-SNAPSHOT"]
                  [net.mikera/imagez "0.12.0"]

--- a/examples/pre-trained-models/src/pre_trained_models/fine_tune.clj
+++ b/examples/pre-trained-models/src/pre_trained_models/fine_tune.clj
@@ -34,7 +34,6 @@
 (def model-dir "model")
 (def batch-size 16)
 
-
 ;;; image set is http://www.vision.caltech.edu/Image_Datasets/Caltech101/
 ;; Pictures of objects belonging to 101 categories. About 40 to 800 images per category. Most categories have about 50 images
 
@@ -49,13 +48,13 @@
                   :rand-mirror true}))
 
 (def val-iter (mx-io/image-record-iter
-                 {:path-imgrec "caltech-256/caltech-256-60-val.rec"
-                  :data-name "data"
-                  :label-name "softmax_label"
-                  :batch-size batch-size
-                  :data-shape [3 224 224]
-                  :rand-crop false
-                  :rand-mirror false}))
+               {:path-imgrec "caltech-256/caltech-256-60-val.rec"
+                :data-name "data"
+                :label-name "softmax_label"
+                :batch-size batch-size
+                :data-shape [3 224 224]
+                :rand-crop false
+                :rand-mirror false}))
 
 (defn get-model []
   (let [mod (m/load-checkpoint {:prefix (str model-dir "/resnet-50") :epoch 0})]
@@ -104,9 +103,7 @@
                (mapv #(context/gpu %) (range (Integer/parseInt (or dev-num "1"))))
                (mapv #(context/cpu %) (range (Integer/parseInt (or dev-num "1")))))]
     (println "Running with context devices of" devs)
-   (fine-tune! devs))
-  )
-
+    (fine-tune! devs)))
 
 (comment
 
@@ -126,7 +123,5 @@
 ;; INFO  ml.dmlc.mxnet.Callback$Speedometer: Epoch[0] Batch [120]	Speed: 3.44 samples/sec	Train-accuracy=0.040806
 ;; INFO  ml.dmlc.mxnet.Callback$Speedometer: Epoch[0] Batch [130]	Speed: 3.41 samples/sec	Train-accuracy=0.043893
 ;; INFO  ml.dmlc.mxnet.Callback$Speedometer: Epoch[0] Batch [140]	Speed: 3.42 samples/sec	Train-accuracy=0.045213
-
 )
-
 

--- a/examples/pre-trained-models/src/pre_trained_models/predict_image.clj
+++ b/examples/pre-trained-models/src/pre_trained_models/predict_image.clj
@@ -39,7 +39,6 @@
               out (io/output-stream file)]
     (io/copy in out)))
 
-
 (defn get-image [url show?]
   (let [fname "test-image.jpg"
         _ (download url fname)
@@ -54,8 +53,8 @@
                            pixels)]
     (when show? (img/show image))
     (-> rgb-pixels
-               (flatten)
-               (ndarray/array [1 num-channels h w]))))
+        (flatten)
+        (ndarray/array [1 num-channels h w]))))
 
 (defn predict [img-url show?]
   (let [mod (m/load-checkpoint {:prefix (str model-dir "/resnet-152") :epoch 0})
@@ -110,6 +109,5 @@
   ;;  {:prob 0.023329297, :label "n02083346 canine, canid"})
 
   (feature-extraction) ;=> [1 2048]
-
-  )
+)
 

--- a/examples/profiler/project.clj
+++ b/examples/profiler/project.clj
@@ -16,6 +16,7 @@
 ;;
 
 (defproject profiler "0.1.0-SNAPSHOT"
+  :plugins [[lein-cljfmt "0.5.7"]]
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [org.apache.mxnet.contrib.clojure/clojure-mxnet "1.2.1-SNAPSHOT"]]
   :main profiler.core)

--- a/examples/rnn/project.clj
+++ b/examples/rnn/project.clj
@@ -17,6 +17,7 @@
 
 (defproject rnn "0.1.0-SNAPSHOT"
   :description "RNN example"
-  :main rnn.train-char-rnn
+  :plugins [[lein-cljfmt "0.5.7"]]
   :dependencies [[org.clojure/clojure "1.9.0"]
-                 [org.apache.mxnet.contrib.clojure/clojure-mxnet "1.2.1-SNAPSHOT"]])
+                 [org.apache.mxnet.contrib.clojure/clojure-mxnet "1.2.1-SNAPSHOT"]]
+  :main rnn.train-char-rnn)

--- a/examples/rnn/src/rnn/lstm.clj
+++ b/examples/rnn/src/rnn/lstm.clj
@@ -56,14 +56,14 @@
         cls-weight (sym/variable "cls_weight")
         cls-bias (sym/variable "cls_bias")
         param-cells (mapv (fn [i]
-                             (lstm-param (sym/variable (str "l" i "_i2h_weight"))
-                                         (sym/variable (str "l" i "_i2h_bias"))
-                                         (sym/variable (str "l" i "_h2h_weight"))
-                                         (sym/variable (str "l" i "_h2h_bias"))))
-                           (range 0 num-lstm-layer))
+                            (lstm-param (sym/variable (str "l" i "_i2h_weight"))
+                                        (sym/variable (str "l" i "_i2h_bias"))
+                                        (sym/variable (str "l" i "_h2h_weight"))
+                                        (sym/variable (str "l" i "_h2h_bias"))))
+                          (range 0 num-lstm-layer))
         last-states (mapv (fn [i]
-                             (lstm-state (sym/variable (str "l" i "_init_c_beta"))
-                                         (sym/variable (str "l" i "_init_h_beta"))))
+                            (lstm-state (sym/variable (str "l" i "_init_c_beta"))
+                                        (sym/variable (str "l" i "_init_h_beta"))))
                           (range 0 num-lstm-layer))
         ;; embedding layer
         data (sym/variable "data")
@@ -76,7 +76,7 @@
         hidden-all (doall (for [seq-idx (range seq-len)]
                             (let [hidden (:h (last (loop [i 0
                                                           hidden (sym/get wordvec seq-idx)
-                                                    next-states []]
+                                                          next-states []]
                                                      (if (= i num-lstm-layer)
                                                        next-states
                                                        (let [dp-ratio (if (zero? i) 0 dropout)
@@ -108,14 +108,14 @@
         cls-weight (sym/variable "cls_weight")
         cls-bias (sym/variable "cls_bias")
         param-cells (mapv (fn [i]
-                             (lstm-param (sym/variable (str "l" i "_i2h_weight"))
-                                         (sym/variable (str "l" i "_i2h_bias"))
-                                         (sym/variable (str "l" i "_h2h_weight"))
-                                         (sym/variable (str "l" i "_h2h_bias"))))
-                           (range 0 num-lstm-layer))
+                            (lstm-param (sym/variable (str "l" i "_i2h_weight"))
+                                        (sym/variable (str "l" i "_i2h_bias"))
+                                        (sym/variable (str "l" i "_h2h_weight"))
+                                        (sym/variable (str "l" i "_h2h_bias"))))
+                          (range 0 num-lstm-layer))
         last-states (mapv (fn [i]
-                             (lstm-state (sym/variable (str "l" i "_init_c_beta"))
-                                         (sym/variable (str "l" i "_init_h_beta"))))
+                            (lstm-state (sym/variable (str "l" i "_init_c_beta"))
+                                        (sym/variable (str "l" i "_init_h_beta"))))
                           (range 0 num-lstm-layer))
         data (sym/variable "data")
         dp-ratio 0

--- a/examples/rnn/src/rnn/test_char_rnn.clj
+++ b/examples/rnn/src/rnn/test_char_rnn.clj
@@ -37,11 +37,11 @@
   (let [trained-mod (m/load-checkpoint {:prefix model-prefix :epoch epoch-num})
         trained-arg-params (m/arg-params trained-mod)
         model (lstm/lstm-inference-model {:num-lstm-layer 3
-                                     :input-size (inc (count vocab))
-                                     :num-label (inc (count vocab))
-                                     :num-hidden num-hidden
-                                     :num-embed num-embed
-                                     :arg-params trained-arg-params})
+                                          :input-size (inc (count vocab))
+                                          :num-label (inc (count vocab))
+                                          :num-hidden num-hidden
+                                          :num-embed num-embed
+                                          :arg-params trained-arg-params})
         input-ndarray (ndarray/zeros [1])
         revert-vocab (util/make-revert-vocab vocab)
         fix-dict (into [""]
@@ -68,7 +68,6 @@
                      output
                      (str output next-char)))))))))
 
-
 (comment
 
   (rnn-test "data/obama" 75 200 false)
@@ -76,4 +75,4 @@
 
   (rnn-test "data/obama" 75 200 true)
   ;=>"The joke before them prepared for five years ago, we only hear a chance to lose our efforts and they made striggling procedural deficit at the city between a politics in the efforts on the Edmund Pett"
-  )
+)

--- a/examples/rnn/src/rnn/train_char_rnn.clj
+++ b/examples/rnn/src/rnn/train_char_rnn.clj
@@ -69,15 +69,15 @@
 
 
 (defn build-training-data [path]
-    (let [content (slurp path)
-          sentences (string/split content #"\n")
-          max-length (first buckets)
-          padding-int 0]
-      (doall (for [sentence sentences]
-               (let [ids (mapv #(get vocab %) sentence)]
-                 (if (>= (count ids) max-length)
-                   (into [] (take max-length ids))
-                   (into ids (repeat (- max-length (count ids)) 0))))))))
+  (let [content (slurp path)
+        sentences (string/split content #"\n")
+        max-length (first buckets)
+        padding-int 0]
+    (doall (for [sentence sentences]
+             (let [ids (mapv #(get vocab %) sentence)]
+               (if (>= (count ids) max-length)
+                 (into [] (take max-length ids))
+                 (into ids (repeat (- max-length (count ids)) 0))))))))
 
 (defn build-labels [train-data]
     ;; want to learn the next char some rotate by 1
@@ -89,7 +89,6 @@
         (map vals)
         (first)
         (apply hash-map)))
-
 
 (defn train [devs]
   (let [;; initialize the states for the lstm
@@ -118,7 +117,7 @@
 
         rnn-mod (-> (m/module rnn-sym {:contexts devs})
                     (m/bind {:data-shapes (into (mx-io/provide-data train-iter)
-                                            (mapv (fn [[k v]] {:name k :shape v}) init-states))
+                                                (mapv (fn [[k v]] {:name k :shape v}) init-states))
                              :label-shapes (mx-io/provide-label train-iter)})
                     (m/init-params {:initializer (init/xavier {:factor-type "in" :magnitude 2.34})})
                     (m/init-optimizer {:optimizer (optimizer/adam {:learning-rate learning-rate :wd 0.0001})}))
@@ -138,8 +137,7 @@
                                     (mapv #(Math/log %))
                                     (mapv #(* -1.0 %))
                                     (apply +))]
-                    (float (Math/exp (/ result (count labels)))))
-                  )
+                    (float (Math/exp (/ result (count labels))))))
 
                 "perplexity")]
 
@@ -151,11 +149,11 @@
        (fn [batch-num batch]
          (let [batch (mx-io/next train-iter)]
            (-> rnn-mod
-            (m/forward (mx-io/data-batch {:data (into (mx-io/batch-data batch) init-states-data)
-                                          :label (mx-io/batch-label batch)}))
-            (m/update-metric metric (mx-io/batch-label batch))
-            (m/backward)
-            (m/update))
+               (m/forward (mx-io/data-batch {:data (into (mx-io/batch-data batch) init-states-data)
+                                             :label (mx-io/batch-label batch)}))
+               (m/update-metric metric (mx-io/batch-label batch))
+               (m/backward)
+               (m/update))
            (when (zero? (mod batch-num 10))
              (println "Eval metric for batch-num " batch-num " is " (eval-metric/get metric)))
            (inc batch-num))))
@@ -170,7 +168,6 @@
     (println "Showing the result after 75 epochs (pre-trained)")
     (println (test-rnn/rnn-test "data/obama" 75 200 true))
     (println "=====")))
-
 
 (defn -main [& args]
   (let [[dev dev-num] args

--- a/examples/rnn/src/rnn/util.clj
+++ b/examples/rnn/src/rnn/util.clj
@@ -21,13 +21,13 @@
 (defn build-vocab [path]
   (let [content (slurp path)
         vocab-map (reduce (fn [{:keys [vocab idx] :as result} c]
-                               (if (get vocab c)
-                result
-                (-> result
-                    (update :vocab assoc c (inc idx))
-                    (update :idx inc))))
-                             {:vocab {} :idx 0}     ;; 0 is used for padding
-                             content)]
+                            (if (get vocab c)
+                              result
+                              (-> result
+                                  (update :vocab assoc c (inc idx))
+                                  (update :idx inc))))
+                          {:vocab {} :idx 0}     ;; 0 is used for padding
+                          content)]
     (:vocab vocab-map)))
 
 (defn make-revert-vocab [vmap]
@@ -42,9 +42,8 @@
 
 (defn cdf [weights]
   (let [total (* 1.0 (apply + weights))
-        csums (reduce (fn [cumsum w] (conj cumsum (+ (or (last cumsum) 0) w)) ) [] weights)]
+        csums (reduce (fn [cumsum w] (conj cumsum (+ (or (last cumsum) 0) w))) [] weights)]
     (mapv #(/ % total) csums)))
-
 
 (defn choice [population weights]
   (assert (= (count population) (count weights)))

--- a/examples/tutorial/project.clj
+++ b/examples/tutorial/project.clj
@@ -17,5 +17,6 @@
 
 (defproject tutorial "0.1.0-SNAPSHOT"
   :description "MXNET tutorials"
+  :plugins [[lein-cljfmt "0.5.7"]]
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [org.apache.mxnet.contrib.clojure/clojure-mxnet "1.2.1-SNAPSHOT"]])

--- a/examples/tutorial/src/tutorial/kvstore.clj
+++ b/examples/tutorial/src/tutorial/kvstore.clj
@@ -48,7 +48,7 @@
 (def cpus [(context/cpu 0) (context/cpu 1) (context/cpu 2)])
 (def b [(ndarray/ones shape {:ctx (nth cpus 0)})
         (ndarray/ones shape {:ctx (nth cpus 1)})
-        (ndarray/ones shape {:ctx (nth cpus 2)}) ])
+        (ndarray/ones shape {:ctx (nth cpus 2)})])
 (kvstore/push kv ["3" "3" "3"] b)
 (kvstore/pull kv "3" a)
 (ndarray/->vec a) ;=> [3.0 3.0 3.0 3.0 3.0 3.0]
@@ -57,7 +57,7 @@
 ;;Pull
 ;;You’ve already seen how to pull a single key-value pair. Similar to the way that you use the push command, you can pull the value into several devices with a single call.
 (def b [(ndarray/ones shape {:ctx (context/cpu 0)})
-        (ndarray/ones shape {:ctx (context/cpu 1)}) ])
+        (ndarray/ones shape {:ctx (context/cpu 1)})])
 (kvstore/pull kv ["3" "3"] b)
 (map ndarray/->vec b) ;=> ([3.0 3.0 3.0 3.0 3.0 3.0] [3.0 3.0 3.0 3.0 3.0 3.0])
 
@@ -67,7 +67,7 @@
 (def ks ["5" "7" "9"])
 (kvstore/init kv ks [(ndarray/ones shape) (ndarray/ones shape) (ndarray/ones shape)])
 (kvstore/push kv ks [(ndarray/ones shape) (ndarray/ones shape) (ndarray/ones shape)])
-(def b [(ndarray/zeros shape) (ndarray/zeros shape)(ndarray/zeros shape)])
+(def b [(ndarray/zeros shape) (ndarray/zeros shape) (ndarray/zeros shape)])
 (kvstore/pull kv ks b)
 (map ndarray/->vec b);=> ([1.0 1.0 1.0 1.0 1.0 1.0] [1.0 1.0 1.0 1.0 1.0 1.0] [1.0 1.0 1.0 1.0 1.0 1.0])
 

--- a/examples/tutorial/src/tutorial/module.clj
+++ b/examples/tutorial/src/tutorial/module.clj
@@ -31,14 +31,14 @@
 
 ;;; Load the MNIST datasets
 (def train-data (mx-io/mnist-iter {:image (str data-dir "train-images-idx3-ubyte")
-                                       :label (str data-dir "train-labels-idx1-ubyte")
-                                       :label-name "softmax_label"
-                                       :input-shape [784]
-                                       :batch-size 10
-                                       :shuffle true
-                                       :flat true
-                                       :silent false
-                                       :seed 10}))
+                                   :label (str data-dir "train-labels-idx1-ubyte")
+                                   :label-name "softmax_label"
+                                   :input-shape [784]
+                                   :batch-size 10
+                                   :shuffle true
+                                   :flat true
+                                   :silent false
+                                   :seed 10}))
 
 (def test-data (mx-io/mnist-iter {:image (str data-dir "t10k-images-idx3-ubyte")
                                   :label (str data-dir "t10k-labels-idx1-ubyte")
@@ -131,10 +131,10 @@
 
 (let [save-prefix "my-model"]
   (doseq [epoch-num (range 3)]
-        (mx-io/do-batches train-data (fn [batch
+    (mx-io/do-batches train-data (fn [batch
                                           ;; do something
-                                          ]))
-        (m/save-checkpoint mod {:prefix save-prefix :epoch epoch-num :save-opt-states true})))
+]))
+    (m/save-checkpoint mod {:prefix save-prefix :epoch epoch-num :save-opt-states true})))
 
 ;; INFO  ml.dmlc.mxnet.module.Module: Saved checkpoint to my-model-0000.params
 ;; INFO  ml.dmlc.mxnet.module.Module: Saved optimizer state to my-model-0000.states
@@ -155,8 +155,8 @@
 ;;To get current parameters, use `params`
 
 (let [[arg-params aux-params] (m/params new-mod)]
-     {:arg-params arg-params
-      :aux-params aux-params})
+  {:arg-params arg-params
+   :aux-params aux-params})
 
 ;; {:arg-params
 ;;  {"fc3_bias"
@@ -188,32 +188,5 @@
                 :fit-params (-> (m/fit-params {:begin-epoch 1}))})
 
 ;;Create fit-params, and then use it to set `begin-epoch` so that fit() knows to resume from a saved epoch.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 

--- a/examples/visualization/project.clj
+++ b/examples/visualization/project.clj
@@ -17,6 +17,7 @@
 
 (defproject visualization "0.1.0-SNAPSHOT"
   :description "Visualization example"
-  :main visualization.core
+  :plugins [[lein-cljfmt "0.5.7"]]
   :dependencies [[org.clojure/clojure "1.9.0"]
-                 [org.apache.mxnet.contrib.clojure/clojure-mxnet "1.2.1-SNAPSHOT"]])
+                 [org.apache.mxnet.contrib.clojure/clojure-mxnet "1.2.1-SNAPSHOT"]]
+  :main visualization.core)

--- a/examples/visualization/src/visualization/core.clj
+++ b/examples/visualization/src/visualization/core.clj
@@ -25,10 +25,7 @@
     #_(sym/convolution "conv1" {:data data :kernel [3 3] :num-filter 32 :stride [2 2]})
     #_(sym/batch-norm "bn1" {:data data})
     #_(sym/activation "relu1" {:data data :act-type "relu"})
-    #_(sym/pooling "mp1" {:data data :kernel [2 2] :pool-type "max" :stride [2 2]})
-
-
-    #_(sym/convolution "conv2" {:data data :kernel [3 3] :num-filter 32 :stride [2 2]})
+    #_(sym/pooling "mp1" {:data data :kernel [2 2] :pool-type "max" :stride [2 2]}) #_(sym/convolution "conv2" {:data data :kernel [3 3] :num-filter 32 :stride [2 2]})
     #_(sym/batch-norm "bn2" {:data data})
     #_(sym/activation "relu2" {:data data :act-type "relu"})
     #_(sym/pooling "mp2" {:data data :kernel [2 2] :pool-type "max" :stride [2 2]})
@@ -39,12 +36,11 @@
 
 (defn test-viz []
   (let [dot (viz/plot-network (get-symbol)
-                          {"data" [1 1 28 28]}
-                          {:title "foo" :node-attrs {:shape "oval" :fixedsize "false"}})]
+                              {"data" [1 1 28 28]}
+                              {:title "foo" :node-attrs {:shape "oval" :fixedsize "false"}})]
     (viz/render dot "testviz" "./")))
 
 (defn -main [& args]
   (do (test-viz)
       (println "Check for the testviz.pdf file in the project directory")))
-
 

--- a/lein-cljfmt-check
+++ b/lein-cljfmt-check
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+## Keep the code style consistent using cljfmt
+## Note: we intentionally skip the ./src/org/apache/clojure_mxnet/gen from the list
+lein cljfmt check `find ./src/org/apache/clojure_mxnet -depth 1 -type f -iname "*.clj"`
+
+## And for the test directory
+lein cljfmt check `find ./test -type f -iname "*.clj"`

--- a/lein-cljfmt-fix
+++ b/lein-cljfmt-fix
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+## Keep the code style consistent using cljfmt
+## Note: we intentionally skip the ./src/org/apache/clojure_mxnet/gen from the list
+lein cljfmt fix `find ./src/org/apache/clojure_mxnet -depth 1 -type f -iname "*.clj"`
+
+## And for the test directory
+lein cljfmt fix `find ./test -type f -iname "*.clj"`

--- a/project.clj
+++ b/project.clj
@@ -28,7 +28,8 @@
                  [org.apache.logging.log4j/log4j-api "2.8.1"]
                  [org.slf4j/slf4j-log4j12 "1.7.25" :exclusions [org.slf4j/slf4j-api]]]
   :pedantic? :skip
-  :plugins [[lein-codox "0.10.3" :exclusions [org.clojure/clojure]]
+  :plugins [[lein-cljfmt "0.5.7"]
+            [lein-codox "0.10.3" :exclusions [org.clojure/clojure]]
             [lein-cloverage "1.0.10" :exclusions [org.clojure/clojure]]]
   :codox {:namespaces [#"^org\.apache\.clojure-mxnet\.(?!gen).*"]}
   :aliases {"generate-code" ["run" "-m" "dev.generator"]}


### PR DESCRIPTION
Hi @gigasquid 

Leverage [cljfmt](https://github.com/weavejester/cljfmt) as ways for us to use the same style for the codebase starting with the example codes. The last commit contains the script that I use

- `lein cljfmt fix` #=> run the fix

#### Benefit:

Everyone who would be contributor can use different editor (Emacs/Vim/Cursive, etc) but we can still contribute using the same style.

The script used:

```sh
#!/usr/bin/env bash
for dir in $(find . -type d -depth 1 | grep -v scripts)
do
  cd $dir
  lein cljfmt fix
  cd ..
done
```
In this PR, I added `lein-cljfmt` to the plugins vector and then create two simple scripts
one to check for style, and the other for fixing the style automatically.

It is very configurable and can be adjusted to your preferred styles if you like. More information can be found in the [cljfmt's readme](https://github.com/weavejester/cljfmt/blob/master/README.md) file.

Please note that I only apply the script to the examples projects, but leave the main project intact.
If you are ok with this then you can run the script in the base directory (one for check one for fix style).

As it will probably changes most of the code (excluding the generated file), so I leave it up to you
to decide if you want to do it. Or if you want I can create a new PR to contain the result of applying the script to the main src/test codes.

Thanks
Burin