### PR TITLE
skip validation in fit when eval-data is nil

### DIFF
--- a/src/org/apache/clojure_mxnet/module.clj
+++ b/src/org/apache/clojure_mxnet/module.clj
@@ -596,8 +596,9 @@
          (callback/invoke cb i 0 val-metric))
 
        ;; evaluation on the validation set
-       (let [res (score fmod {:eval-data eval-data :eval-metric eval-metric :epoch i})]
-         (println "Epoch " i " Validation- " res))))
+       (when eval-data
+         (let [res (score fmod {:eval-data eval-data :eval-metric eval-metric :epoch i})]
+           (println "Epoch " i " Validation- " res)))))
     fmod)
   ;; old way if the problem with the sizes get resolved in DataDesc
   #_(doto mod
@@ -686,5 +687,3 @@
       (fit-params {})
 
   )
-
-


### PR DESCRIPTION
When no evaluation data is passed into `fit`, don't try to use `score` to validate.